### PR TITLE
allow comma separated list for filter items in tokens.ts

### DIFF
--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -32,9 +32,10 @@ export const useTokens = defineStore('tokens', {
             const q = state.q.toLowerCase().trim()
             let result = state.rawItems
             if (q != '') {
-                result = result.filter(
-                    (a) => a.name.toLowerCase().indexOf(q) >= 0
-                )
+              const qs = state.q.toLowerCase().split(',').map(term => term.trim()).filter(term => term != '');
+              result = result.filter(
+                (a) => qs.some(q => a.name.toLowerCase().indexOf(q) >= 0)
+              )
             }
             if (state.colors.length > 0) {
                 result = result.filter(
@@ -46,6 +47,7 @@ export const useTokens = defineStore('tokens', {
             }
             return result
         },
+
         getItemByKey: (state) => {
             return (key: string) => {
                 return state.rawItems.find((a) => a.key === key)


### PR DESCRIPTION
quick mod to allow search/filter of Mutiple terms using a comma separated list.  this allows you to store a txt string for each characters inventory and quickly bring them up in the app.  I plan to add: 
0. allow to specify exact item name using double quotes so "bracer" doesn't bring up "tactical bracers"
1. browser local storage for the filter query so you dont need to paste it in .. just chose which store state to restore. 
2. choose between multiple inventory stores ( 4 characters + ship)
3. create & delete X number of inventory stores